### PR TITLE
Production Preview should run during PR

### DIFF
--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -89,7 +89,6 @@ jobs:
 
   pulumi-staging:
     uses: ./.github/workflows/pulumi-aws.yml
-    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     needs: [ lint ]
     with:
       AWS_REGION: {% endraw %}{{ aws_region_for_stack }}{% raw %}
@@ -132,6 +131,6 @@ jobs:
           echo ${{ needs.ephemeral-test.result }}
           echo ${{ needs.pulumi-prod.result }}
       - name: fail if prior job failure
-        if: needs.lint.result != 'success' || (needs.pulumi-staging.result != 'success' && needs.pulumi-staging.result != 'skipped') || (needs.get-values.result != 'success' && needs.get-values.result != 'skipped') || (needs.ephemeral-test.result != 'success' && needs.ephemeral-test.result != 'skipped') || (needs.pulumi-prod.result != 'success' && needs.pulumi-prod.result != 'skipped')
+        if: needs.lint.result != 'success' || needs.pulumi-staging.result != 'success' || (needs.get-values.result != 'success' && needs.get-values.result != 'skipped') || (needs.ephemeral-test.result != 'success' && needs.ephemeral-test.result != 'skipped') || (needs.pulumi-prod.result != 'success' && needs.pulumi-prod.result != 'skipped')
         run: |
           exit 1{% endraw %}

--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -89,6 +89,7 @@ jobs:
 
   pulumi-staging:
     uses: ./.github/workflows/pulumi-aws.yml
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     needs: [ lint ]
     with:
       AWS_REGION: {% endraw %}{{ aws_region_for_stack }}{% raw %}
@@ -104,7 +105,7 @@ jobs:
 
   pulumi-prod:
     uses: ./.github/workflows/pulumi-aws.yml
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     needs: [ pulumi-staging ]
     with:
       AWS_REGION: {% endraw %}{{ aws_region_for_stack }}{% raw %}
@@ -114,7 +115,7 @@ jobs:
       DEPLOY_SCRIPT_MODULE_NAME: infra
       PULUMI_PREVIEW: true
       PREVIEW_ROLE_NAME: InfraPreview--{% endraw %}{{ repo_name }}{% raw %}
-      PULUMI_UP: true
+      PULUMI_UP: ${{ github.ref == 'refs/heads/main' }}
       PULUMI_UP_ROLE_NAME: InfraDeploy--{% endraw %}{{ repo_name }}{% raw %}
       AWS_ACCOUNT_ID: "{% endraw %}{{ aws_production_account_id }}{% raw %}"
 
@@ -131,6 +132,6 @@ jobs:
           echo ${{ needs.ephemeral-test.result }}
           echo ${{ needs.pulumi-prod.result }}
       - name: fail if prior job failure
-        if: needs.lint.result != 'success' || needs.pulumi-staging.result != 'success' || (needs.get-values.result != 'success' && needs.get-values.result != 'skipped') || (needs.ephemeral-test.result != 'success' && needs.ephemeral-test.result != 'skipped') || (needs.pulumi-prod.result != 'success' && needs.pulumi-prod.result != 'skipped')
+        if: needs.lint.result != 'success' || (needs.pulumi-staging.result != 'success' && needs.pulumi-staging.result != 'skipped') || (needs.get-values.result != 'success' && needs.get-values.result != 'skipped') || (needs.ephemeral-test.result != 'success' && needs.ephemeral-test.result != 'skipped') || (needs.pulumi-prod.result != 'success' && needs.pulumi-prod.result != 'skipped')
         run: |
           exit 1{% endraw %}


### PR DESCRIPTION
 ## Why is this change necessary?
We should be able to see a preview against the production stack


 ## How does this change address the issue?
Adds it during CI jobs for PRs


 ## What side effects does this change have?
longer CI


 ## How is this change tested?
Watching CI in downstream repo
