### PR TITLE
Need to echo it to terminal when its too long

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,7 +6,7 @@ reviews:
     - path: "**/vendor_files/**"
       instructions: "These files came from a vendor and we're not allowed to change them. Refer to it if you need to understand how the main code interacts with it, but do not make comments about it."
     - path: "**/*.py"
-      instructions: "Do not express concerns about assert statements being removed by using the -O python flag; we never use that flag. Do not express concerns about ruff rules; a pre-commit hook already runs a ruff check. Do not warn about unnecessary super().init() calls; pyright prefers those to be present."
+      instructions: "Check the `ruff.toml` and `ruff-test.toml` for linting rules we've explicitly disabled and don't suggest changes to please conventions we've disabled. Do not express concerns about ruff rules; a pre-commit hook already runs a ruff check. Do not warn about unnecessary super().__init__() calls; pyright prefers those to be present. Do not warn about missing type hints; a pre-commit hook already checks for that."
   tools:
     eslint: # when the code contains typescript, eslint will be run by pre-commit, and coderabbit often generates false positives
       enabled: false

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.100-2-g404822d
+_commit: v0.0.101
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: Template for a Pulumi Project that is just creating infrastructure (no
     application code)

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.98
+_commit: v0.0.100-1-g5208314
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: Template for a Pulumi Project that is just creating infrastructure (no
     application code)

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.100-1-g5208314
+_commit: v0.0.100-2-g404822d
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: Template for a Pulumi Project that is just creating infrastructure (no
     application code)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
       "extensions": [
         // basic tooling
         // "eamodio.gitlens@15.5.1",
-        "coderabbit.coderabbit-vscode@0.18.1",
+        "coderabbit.coderabbit-vscode@0.18.3",
         "ms-vscode.live-server@0.5.2025051301",
         "MS-vsliveshare.vsliveshare@1.0.5905",
         "github.copilot@1.388.0",
@@ -58,5 +58,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): d3f386ef # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): b0b986f0 # spellchecker:disable-line
 }

--- a/.devcontainer/install-ci-tooling.py
+++ b/.devcontainer/install-ci-tooling.py
@@ -7,7 +7,7 @@ import sys
 import tempfile
 from pathlib import Path
 
-UV_VERSION = "0.10.7"
+UV_VERSION = "0.10.8"
 PNPM_VERSION = "10.30.3"
 COPIER_VERSION = "==9.12.0"
 COPIER_TEMPLATE_EXTENSIONS_VERSION = "==0.3.3"

--- a/.github/reusable_workflows/build-docker-image.yaml
+++ b/.github/reusable_workflows/build-docker-image.yaml
@@ -156,7 +156,7 @@ jobs:
 
       - name: Upload Docker Image Artifact
         if: ${{ inputs.save-as-artifact }}
-        uses: actions/upload-artifact@v6.0.0
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: ${{ steps.calculate-build-context-hash.outputs.image_name_no_slashes }}
           path: ${{ steps.calculate-build-context-hash.outputs.image_name_no_slashes }}.tar

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,7 +147,7 @@ jobs:
         timeout-minutes: 8  # this is the amount of time this action will wait to attempt to acquire the mutex lock before failing, e.g. if other jobs are queued up in front of it
 
       - name: Cache Pre-commit hooks
-        uses: actions/cache@v5.0.2
+        uses: actions/cache@v5.0.3
         env:
           cache-name: cache-pre-commit-hooks
         with:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -59,7 +59,7 @@ jobs:
         timeout-minutes: 8  # this is the amount of time this action will wait to attempt to acquire the mutex lock before failing, e.g. if other jobs are queued up in front of it
 
       - name: Cache Pre-commit hooks
-        uses: actions/cache@v5.0.2
+        uses: actions/cache@v5.0.3
         env:
           cache-name: cache-pre-commit-hooks
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 - Don't sort or remove imports manually — pre-commit handles it.
 - Always include type hints for pyright in Python
 - Respect the pyright rule reportUnusedCallResult; assign unneeded return values to `_`
-- Prefer keyword-only parameters: use `*` in Python signatures and destructured options objects in TypeScript.
+- Prefer keyword-only parameters (unless a very clear single-argument function): use `*` in Python signatures and destructured options objects in TypeScript.
 
 ## Testing
 - Always run tests with an explicit path (e.g. uv run pytest tests/unit) — test runners discover all types by default.
@@ -12,9 +12,15 @@
 - Avoid magic values in comparisons in tests in all languages (like ruff rule PLR2004 specifies)
 - Prefer using random values in tests rather than arbitrary ones (e.g. the faker library, uuids, random.randint) when possible.
 
+### Python Testing
+- When using `mocker.spy` on a class-level method (including inherited ones), the spy records the unbound call, so assertions need `ANY` as the first argument to match self:  `spy.assert_called_once_with(ANY, expected_arg)`
+- Before writing new mock/spy helpers, check the `tests/unit/` folder for pre-built helpers in files like `fixtures.py` or `*mocks.py`
+
+
 ## Tooling
 - Always use `uv run python` instead of `python3` or `python` when running Python commands.
 - Check .devcontainer/devcontainer.json for tooling versions (Python, Node, etc.) when reasoning about version-specific stdlib or tooling behavior.
+- For frontend work, run commands via `pnpm` scripts from `frontend/package.json`
 <!-- Allows better automated utilization of command allow/deny list -->
 - When running terminal commands, execute exactly one command per tool call. Do not chain commands with &&, ||, ;, or & unless the user explicitly asks for it. Pipes (|) are allowed for output transformation (e.g., head, tail, grep). If two sequential commands are needed, run them in separate tool calls.
 

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -10,7 +10,7 @@ class ContextUpdater(ContextHook):
 
     @override
     def hook(self, context: dict[Any, Any]) -> dict[Any, Any]:
-        context["uv_version"] = "0.10.7"
+        context["uv_version"] = "0.10.8"
         context["pnpm_version"] = "10.30.3"
         context["pre_commit_version"] = "4.5.1"
         context["pyright_version"] = ">=1.1.408"
@@ -33,7 +33,7 @@ class ContextUpdater(ContextHook):
         context["pyinstaller_version"] = ">=6.19.0"
         context["setuptools_version"] = "80.7.1"
         context["strawberry_graphql_version"] = ">=0.298.0"
-        context["fastapi_version"] = ">=0.129.0"
+        context["fastapi_version"] = ">=0.135.1"
         context["fastapi_offline_version"] = ">=1.7.4"
         context["uvicorn_version"] = ">=0.41.0"
         context["lab_auto_pulumi_version"] = ">=0.1.18"
@@ -51,7 +51,7 @@ class ContextUpdater(ContextHook):
         context["python_faker_version"] = ">=40.4.0"
 
         context["default_node_version"] = "24.11.1"
-        context["nuxt_ui_version"] = "^4.4.0"
+        context["nuxt_ui_version"] = "^4.5.1"
         context["nuxt_version"] = "^4.3.1"
         context["nuxt_icon_version"] = "^2.2.1"
         context["typescript_version"] = "^5.9.3"
@@ -79,14 +79,14 @@ class ContextUpdater(ContextHook):
         context["vue_test_utils_version"] = "^2.4.6"
         context["nuxt_test_utils_version"] = "3.19.1"
         context["vue_eslint_parser_version"] = "^10.4.0"
-        context["happy_dom_version"] = "^20.6.3"
+        context["happy_dom_version"] = "^20.8.3"
         context["node_kiota_bundle_version"] = "1.0.0-preview.99"
 
         context["gha_checkout"] = "v6.0.2"
         context["gha_setup_python"] = "v6.2.0"
-        context["gha_cache"] = "v5.0.2"
-        context["gha_upload_artifact"] = "v6.0.0"
-        context["gha_download_artifact"] = "v7.0.0"
+        context["gha_cache"] = "v5.0.3"
+        context["gha_upload_artifact"] = "v7.0.0"
+        context["gha_download_artifact"] = "v8.0.0"
         context["gha_github_script"] = "v7.0.1"
         context["gha_setup_buildx"] = "v3.11.1"
         context["buildx_version"] = "v0.27.0"

--- a/template/.claude/helpers/merge-claude-settings.sh
+++ b/template/.claude/helpers/merge-claude-settings.sh
@@ -72,6 +72,9 @@ merged_json=$(echo "$parsed_json" | jq -s '
             # Collect allow patterns from all files, flatten, and deduplicate
             allow: ([.[].permissions.allow // [] | .[] ] | unique),
 
+            # Collect ask patterns from all files, flatten, and deduplicate
+            ask: ([.[].permissions.ask // [] | .[] ] | unique),
+
             # Collect deny patterns from all files, flatten, and deduplicate
             deny: ([.[].permissions.deny // [] | .[] ] | unique)
         }

--- a/template/.coderabbit.yaml
+++ b/template/.coderabbit.yaml
@@ -6,7 +6,7 @@ reviews:
     - path: "**/vendor_files/**"
       instructions: "These files came from a vendor and we're not allowed to change them. Refer to it if you need to understand how the main code interacts with it, but do not make comments about it."
     - path: "**/*.py"
-      instructions: "Do not express concerns about assert statements being removed by using the -O python flag; we never use that flag. Do not express concerns about ruff rules; a pre-commit hook already runs a ruff check. Do not warn about unnecessary super().init() calls; pyright prefers those to be present."
+      instructions: "Check the `ruff.toml` and `ruff-test.toml` for linting rules we've explicitly disabled and don't suggest changes to please conventions we've disabled. Do not express concerns about ruff rules; a pre-commit hook already runs a ruff check. Do not warn about unnecessary super().__init__() calls; pyright prefers those to be present. Do not warn about missing type hints; a pre-commit hook already checks for that."
   tools:
     eslint: # when the code contains typescript, eslint will be run by pre-commit, and coderabbit often generates false positives
       enabled: false

--- a/template/.devcontainer/devcontainer.json.jinja
+++ b/template/.devcontainer/devcontainer.json.jinja
@@ -35,7 +35,7 @@
         "-AmazonWebServices.aws-toolkit-vscode", // the AWS CLI feature installs this automatically, but it's causing problems in VS Code{% endraw %}{% endif %}{% raw %}
         // basic tooling
         // "eamodio.gitlens@15.5.1",
-        "coderabbit.coderabbit-vscode@0.18.1",
+        "coderabbit.coderabbit-vscode@0.18.3",
         "ms-vscode.live-server@0.5.2025051301",
         "MS-vsliveshare.vsliveshare@1.0.5905",
         "github.copilot@1.388.0",

--- a/template/.devcontainer/on-create-command.sh.jinja
+++ b/template/.devcontainer/on-create-command.sh.jinja
@@ -12,7 +12,7 @@ repo_root="$(CDPATH= cd -- "$script_dir/.." && pwd)"
 mkdir -p "$repo_root/.claude"
 chmod -R ug+rwX "$repo_root/.claude"
 chgrp -R 0 "$repo_root/.claude" || true
-npm --prefix "$repo_root/.claude" install
+npm --prefix "$repo_root/.claude" ci
 
 # Install beads for use in Claude planning
 npm install -g @beads/bd@0.57.0 # no specific reason for this version, just pinning for best practice{% endraw %}{% endif %}{% raw %}

--- a/template/.github/actions/pulumi_ephemeral_deploy/action.yml
+++ b/template/.github/actions/pulumi_ephemeral_deploy/action.yml
@@ -81,9 +81,10 @@ runs:
     - name: Run CLI
       run: |
         output=$(uv --directory ${{ github.workspace }}/${{ inputs.project-dir }} run python -m ${{ inputs.deploy-script-module-name }}.${{ inputs.deploy-script-name }} --stack=${{ inputs.stack-name }} ${{ inputs.cli-action }})
-        echo "$output"
+        echo $output
 
         header=":eyes: **Pulumi Preview for ${{ inputs.deploy-script-module-name }} stack ${{ inputs.stack-name }}:** :eyes:"
+
         cat > /tmp/pulumi-preview-comment.md << EOF
         $header
 

--- a/template/.github/actions/pulumi_ephemeral_deploy/action.yml
+++ b/template/.github/actions/pulumi_ephemeral_deploy/action.yml
@@ -81,8 +81,9 @@ runs:
     - name: Run CLI
       run: |
         output=$(uv --directory ${{ github.workspace }}/${{ inputs.project-dir }} run python -m ${{ inputs.deploy-script-module-name }}.${{ inputs.deploy-script-name }} --stack=${{ inputs.stack-name }} ${{ inputs.cli-action }})
-        header=":eyes: **Pulumi Preview for ${{ inputs.deploy-script-module-name }} stack ${{ inputs.stack-name }}:** :eyes:"
+        echo "$output"
 
+        header=":eyes: **Pulumi Preview for ${{ inputs.deploy-script-module-name }} stack ${{ inputs.stack-name }}:** :eyes:"
         cat > /tmp/pulumi-preview-comment.md << EOF
         $header
 
@@ -92,7 +93,6 @@ runs:
         EOF
 
         if [ $(wc -c < /tmp/pulumi-preview-comment.md) -gt 65535 ]; then
-          echo "$output"
           cat > /tmp/pulumi-preview-comment.md << EOF
         $header
 

--- a/template/.github/actions/pulumi_ephemeral_deploy/action.yml
+++ b/template/.github/actions/pulumi_ephemeral_deploy/action.yml
@@ -81,7 +81,7 @@ runs:
     - name: Run CLI
       run: |
         output=$(uv --directory ${{ github.workspace }}/${{ inputs.project-dir }} run python -m ${{ inputs.deploy-script-module-name }}.${{ inputs.deploy-script-name }} --stack=${{ inputs.stack-name }} ${{ inputs.cli-action }})
-        echo $output
+        echo "$output"
 
         header=":eyes: **Pulumi Preview for ${{ inputs.deploy-script-module-name }} stack ${{ inputs.stack-name }}:** :eyes:"
 

--- a/template/.github/actions/pulumi_ephemeral_deploy/action.yml
+++ b/template/.github/actions/pulumi_ephemeral_deploy/action.yml
@@ -92,6 +92,7 @@ runs:
         EOF
 
         if [ $(wc -c < /tmp/pulumi-preview-comment.md) -gt 65535 ]; then
+          echo "$output"
           cat > /tmp/pulumi-preview-comment.md << EOF
         $header
 

--- a/template/.github/workflows/pre-commit.yaml
+++ b/template/.github/workflows/pre-commit.yaml
@@ -59,7 +59,7 @@ jobs:
         timeout-minutes: 8  # this is the amount of time this action will wait to attempt to acquire the mutex lock before failing, e.g. if other jobs are queued up in front of it
 
       - name: Cache Pre-commit hooks
-        uses: actions/cache@v5.0.2
+        uses: actions/cache@v5.0.3
         env:
           cache-name: cache-pre-commit-hooks
         with:

--- a/template/.github/workflows/pulumi-aws.yml
+++ b/template/.github/workflows/pulumi-aws.yml
@@ -124,7 +124,7 @@ jobs:
           python-version: ${{ inputs.PYTHON_VERSION }}
 
       - name: Download Artifact
-        uses: actions/download-artifact@v7.0.0
+        uses: actions/download-artifact@v8.0.0
         if: ${{ inputs.DOWNLOAD_ARTIFACT_NAME != '' }}
         with:
           name: ${{ inputs.DOWNLOAD_ARTIFACT_NAME }}

--- a/template/AGENTS.md
+++ b/template/AGENTS.md
@@ -4,7 +4,7 @@
 - Don't sort or remove imports manually — pre-commit handles it.
 - Always include type hints for pyright in Python
 - Respect the pyright rule reportUnusedCallResult; assign unneeded return values to `_`
-- Prefer keyword-only parameters: use `*` in Python signatures and destructured options objects in TypeScript.
+- Prefer keyword-only parameters (unless a very clear single-argument function): use `*` in Python signatures and destructured options objects in TypeScript.
 
 ## Testing
 - Always run tests with an explicit path (e.g. uv run pytest tests/unit) — test runners discover all types by default.
@@ -12,9 +12,15 @@
 - Avoid magic values in comparisons in tests in all languages (like ruff rule PLR2004 specifies)
 - Prefer using random values in tests rather than arbitrary ones (e.g. the faker library, uuids, random.randint) when possible.
 
+### Python Testing
+- When using `mocker.spy` on a class-level method (including inherited ones), the spy records the unbound call, so assertions need `ANY` as the first argument to match self:  `spy.assert_called_once_with(ANY, expected_arg)`
+- Before writing new mock/spy helpers, check the `tests/unit/` folder for pre-built helpers in files like `fixtures.py` or `*mocks.py`
+
+
 ## Tooling
 - Always use `uv run python` instead of `python3` or `python` when running Python commands.
 - Check .devcontainer/devcontainer.json for tooling versions (Python, Node, etc.) when reasoning about version-specific stdlib or tooling behavior.
+- For frontend work, run commands via `pnpm` scripts from `frontend/package.json`
 <!-- Allows better automated utilization of command allow/deny list -->
 - When running terminal commands, execute exactly one command per tool call. Do not chain commands with &&, ||, ;, or & unless the user explicitly asks for it. Pipes (|) are allowed for output transformation (e.g., head, tail, grep). If two sequential commands are needed, run them in separate tool calls.
 


### PR DESCRIPTION
## Why is this change necessary?
When we have a PR comment that exceeds the size of the allowed limit we fixed it by sending a smaller message and link but when you go review the output the actual command output was not available for review. 


## How does this change address the issue?
Outputs the command output when the value is too long.


## What side effects does this change have?
Shows the preview output now


## How is this change tested?
CI



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved ephemeral deployment logging to surface command output during runs.
  * Updated CI/workflow tooling versions and caching/upload steps for reliability.
  * Switched devcontainer setup to use deterministic dependency install behavior.

* **Documentation**
  * Clarified Python testing and linting guidance; added frontend tooling notes (use pnpm).
  * Added guidance on reusing test helpers.

* **Other**
  * Settings merge now collects a new permissions category ("ask") when combining configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->