### PR TITLE
To check the value need to have it in the needs section

### DIFF
--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -131,6 +131,7 @@ jobs:
       - get-values
       - pre-commit
       - check-skip-duplicate
+      - confirm-on-tagged-copier-template
       - ephemeral-test
       - pulumi-staging
       - pulumi-prod


### PR DESCRIPTION
## Link to Issue or Message thread
Downstream failure


## Why is this change necessary?
During merging missed adding - confirm-on-tagged-copier-template to the needs definition so when checking the status it was empty.


## How does this change address the issue?
Adds the correct job dependency


## What side effects does this change have?
N/A


## How is this change tested?
Downstream

